### PR TITLE
Enhancements for Ore

### DIFF
--- a/include/probeoptimizer/probe_arrangement.h
+++ b/include/probeoptimizer/probe_arrangement.h
@@ -22,6 +22,8 @@ public:
         usedProbes_(other.usedProbes_), setupDirty_(other.setupDirty_.load()),
         setup_(other.setup_), storage_weight_(other.storage_weight_),
         production_weight_(other.production_weight_),
+        ore_multiplier_(other.ore_multiplier_),
+        require_ores_(other.require_ores_),
         revenue_weight_(other.revenue_weight_) {}
   ProbeArrangement(ProbeArrangement &&other) noexcept
       : probes_(std::move(other.probes_)),
@@ -30,6 +32,8 @@ public:
         setupDirty_(other.setupDirty_.load()), setup_(std::move(other.setup_)),
         storage_weight_(other.storage_weight_),
         production_weight_(other.production_weight_),
+        ore_multiplier_(other.ore_multiplier_),
+        require_ores_(other.require_ores_),
         revenue_weight_(other.revenue_weight_) {}
   ProbeArrangement &operator=(const ProbeArrangement &other) {
     if (this == &other)
@@ -41,6 +45,8 @@ public:
     setup_ = other.setup_;
     storage_weight_ = other.storage_weight_;
     production_weight_ = other.production_weight_;
+    ore_multiplier_ = other.ore_multiplier_;
+    require_ores_ = other.require_ores_;
     revenue_weight_ = other.revenue_weight_;
     return *this;
   }
@@ -54,6 +60,8 @@ public:
     setup_ = std::move(other.setup_);
     storage_weight_ = other.storage_weight_;
     production_weight_ = other.production_weight_;
+    ore_multiplier_ = other.ore_multiplier_;
+    require_ores_ = other.require_ores_;
     revenue_weight_ = other.revenue_weight_;
     return *this;
   }
@@ -80,6 +88,10 @@ public:
   void setProductionWeight(double production_weight);
   double getRevenueWeight() const;
   void setRevenueWeight(double revenue_weight);
+  double getOreMultiplier() const;
+  void setOreMultiplier(double ore_multiplier);
+  bool getRequireOres() const;
+  void setRequireOres(bool require_ores);
   double getTotalProduction() const;
   double getTotalRevenue() const;
   double getTotalStorage() const;
@@ -96,6 +108,7 @@ private:
   int getComboSize(size_t source) const;
   double getProbeBoost(size_t idx) const noexcept;
   double getProbeProduction(size_t idx) const noexcept;
+  double getProductionNodeMultiplier(size_t idx) const noexcept;
   double getProduction(size_t idx) const noexcept;
   double getProbeRevenue(size_t idx) const noexcept;
   double getRevenue(size_t idx) const noexcept;
@@ -116,6 +129,8 @@ private:
   double storage_weight_ = 1;
   double production_weight_ = 1;
   double revenue_weight_ = 1;
+  double ore_multiplier_ = 1;
+  bool require_ores_ = false;
 };
 
 #endif // XENOPROBES_PROBE_ARRANGEMENT_H

--- a/include/probeoptimizer/probe_optimizer.h
+++ b/include/probeoptimizer/probe_optimizer.h
@@ -59,6 +59,8 @@ public:
   void setMaxAge(int maxAge);
   void setMaxThreads(size_t threads);
   void setProbeAt(Site::Ptr site, Probe::Ptr probe);
+  void setOreMultiplier(float setOreMultiplier);
+  void setRequireOres(bool require_ores);
 
   static void handleSIGINT(int);
   static void requestStop();

--- a/src/probeoptimizer/probe_arrangement.cpp
+++ b/src/probeoptimizer/probe_arrangement.cpp
@@ -357,7 +357,8 @@ double ProbeArrangement::getProbeProduction(size_t idx) const noexcept {
 double
 ProbeArrangement::getProductionNodeMultiplier(size_t idx) const noexcept {
   const auto probe = probes_[idx];
-  if (probe->category != Probe::Category::Mining)
+  if (probe->category != Probe::Category::Mining &&
+      probe->category != Probe::Category::Duplicator)
     return 1;
   const auto site = Site::fromName(ProbeOptimizer::getSiteIdForIndex(idx));
   const auto &ore = site->getOre();

--- a/src/probeoptimizer/probe_arrangement.cpp
+++ b/src/probeoptimizer/probe_arrangement.cpp
@@ -357,10 +357,24 @@ double ProbeArrangement::getProbeProduction(size_t idx) const noexcept {
 double
 ProbeArrangement::getProductionNodeMultiplier(size_t idx) const noexcept {
   const auto probe = probes_[idx];
-  if (probe->category != Probe::Category::Mining &&
-      probe->category != Probe::Category::Duplicator)
-    return 1;
   const auto site = Site::fromName(ProbeOptimizer::getSiteIdForIndex(idx));
+  bool isMining = false;
+  if (probe->category != Probe::Category::Duplicator) {
+    double dupeStash = 0; // things that don't get boosted
+    if (probe->category == Probe::Category::Duplicator) {
+      for (auto neighbor : site->getNeighbors()) {
+        const auto nidx = ProbeOptimizer::getIndexForSiteId(neighbor->name);
+        const auto neighborProbe = probes_[nidx];
+        if (neighborProbe->category == Probe::Category::Mining) {
+          isMining = true;
+          break;
+        }
+      }
+    }
+  } else if (probe->category == Probe::Category::Mining)
+    isMining = true;
+  if (!isMining)
+    return 1;
   const auto &ore = site->getOre();
   if (ore.size() > 0)
     return ore_multiplier_;

--- a/src/probeoptimizer/probe_arrangement.cpp
+++ b/src/probeoptimizer/probe_arrangement.cpp
@@ -77,9 +77,15 @@ double ProbeArrangement::evaluate() const {
   double totalRev = 0;
   double totalStorage = 6000;
   for (size_t i = 0; i < ProbeOptimizer::getSites().size(); ++i) {
-    totalProd += getProduction(i);
+    totalProd += getProduction(i) * getProductionNodeMultiplier(i);
     totalRev += getRevenue(i);
     totalStorage += getStorage(i);
+  }
+
+  if (require_ores_) {
+    const auto ores = getOres();
+    if (ores.size() < Ore::ALL.size())
+      return 0;
   }
 
   return totalStorage * storage_weight_ + totalRev * revenue_weight_ +
@@ -157,6 +163,10 @@ double ProbeArrangement::getProductionWeight() const {
 
 double ProbeArrangement::getRevenueWeight() const { return revenue_weight_; }
 
+double ProbeArrangement::getOreMultiplier() const { return ore_multiplier_; }
+
+bool ProbeArrangement::getRequireOres() const { return require_ores_; }
+
 void ProbeArrangement::setStorageWeight(double storage_weight) {
   storage_weight_ = storage_weight;
 }
@@ -167,6 +177,14 @@ void ProbeArrangement::setProductionWeight(double production_weight) {
 
 void ProbeArrangement::setRevenueWeight(double revenue_weight) {
   revenue_weight_ = revenue_weight;
+}
+
+void ProbeArrangement::setOreMultiplier(double ore_multiplier) {
+  ore_multiplier_ = ore_multiplier;
+}
+
+void ProbeArrangement::setRequireOres(bool require_ores) {
+  require_ores_ = require_ores;
 }
 
 size_t ProbeArrangement::getSize() const { return probes_.size(); }
@@ -334,6 +352,18 @@ double ProbeArrangement::getProbeProduction(size_t idx) const noexcept {
   }
 
   return probeRate + dupeStash;
+}
+
+double
+ProbeArrangement::getProductionNodeMultiplier(size_t idx) const noexcept {
+  const auto probe = probes_[idx];
+  if (probe->category != Probe::Category::Mining)
+    return 1;
+  const auto site = Site::fromName(ProbeOptimizer::getSiteIdForIndex(idx));
+  const auto &ore = site->getOre();
+  if (ore.size() > 0)
+    return ore_multiplier_;
+  return 1;
 }
 
 double ProbeArrangement::getProduction(size_t idx) const noexcept {

--- a/src/probeoptimizer/probe_optimizer.cpp
+++ b/src/probeoptimizer/probe_optimizer.cpp
@@ -212,11 +212,15 @@ void ProbeOptimizer::doHillClimbing(const ProgressCallback& progressCallback,
       "  storage weight   = {storageWeight: 6}\n"
       "  revenue weight   = {revenueWeight: 6}\n"
       "  production weight= {productionWeight: 6}\n"
+      "  ore multiplier   = {oreMultiplier: 6}\n"
+      "  require ores     = {requireOres: >6}\n"
       "  iterations={maxIterations}  offsprings={numOffsprings}"
       "  mutation={mutationRate}  age={maxAge}  population={maxPopSize}",
       fmt::arg("storageWeight", setup_.getStorageWeight()),
       fmt::arg("revenueWeight", setup_.getRevenueWeight()),
       fmt::arg("productionWeight", setup_.getProductionWeight()),
+      fmt::arg("oreMultiplier", setup_.getOreMultiplier()),
+      fmt::arg("requireOres", setup_.getRequireOres()),
       fmt::arg("maxIterations", maxIterations_),
       fmt::arg("numOffsprings", numOffsprings_),
       fmt::arg("mutationRate", mutationRate_), fmt::arg("maxAge", maxAge_),
@@ -308,6 +312,14 @@ void ProbeOptimizer::setRevenueWeight(float revenueWeight) {
 
 void ProbeOptimizer::setProductionWeight(float productionWeight) {
   setup_.setProductionWeight(productionWeight);
+}
+
+void ProbeOptimizer::setOreMultiplier(float oreMultiplier) {
+  setup_.setOreMultiplier(oreMultiplier);
+}
+
+void ProbeOptimizer::setRequireOres(bool requireOres) {
+  setup_.setRequireOres(requireOres);
 }
 
 void ProbeOptimizer::setMutationRate(float mutationRate) {

--- a/src/xenoprobes/main.cpp
+++ b/src/xenoprobes/main.cpp
@@ -58,6 +58,10 @@ po::variables_map parseOptions(int argc, const char **argv,
       "How important is Revenue (cash output.)")(
       "productionweight", po::value<float>()->default_value(1),
       "How important is Production (Miranium output.)")(
+      "oremultiplier", po::value<float>()->default_value(1),
+      "Multiplier to the production value when a node provides an ore.")(
+      "requireores", po::bool_switch()->default_value(false),
+      "Prevent solutions without all ores")(
       "iterations", po::value<size_t>()->default_value(2000),
       "How many iterations to run.")(
       "offsprings,o", po::value<size_t>()->default_value(100),
@@ -81,6 +85,8 @@ po::variables_map parseOptions(int argc, const char **argv,
   optimizer.setStorageWeight(vm["storageweight"].as<float>());
   optimizer.setRevenueWeight(vm["revenueweight"].as<float>());
   optimizer.setProductionWeight(vm["productionweight"].as<float>());
+  optimizer.setOreMultiplier(vm["oremultiplier"].as<float>());
+  optimizer.setRequireOres(vm["requireores"].as<bool>());
   optimizer.setMaxIterations(vm["iterations"].as<size_t>());
   optimizer.setNumOffsprings(vm["offsprings"].as<size_t>());
   optimizer.setMutationRate(vm["mutation"].as<float>());

--- a/src/xenoprobes_gui/CMakeLists.txt
+++ b/src/xenoprobes_gui/CMakeLists.txt
@@ -5,33 +5,35 @@ endif ()
 
 qt_add_executable(${PROJECT_NAME}_gui ${WIN32_OPTION}
         ${PROJECT_SOURCE_DIR}/resources/resources.qrc
-        AboutDialog.h
         AboutDialog.cpp
+        AboutDialog.h
         DataProbe.cpp
         DataProbe.h
+        DoubleSliderWithValWidget.cpp
+        DoubleSliderWithValWidget.h
         FnSiteWidget.cpp
         FnSiteWidget.h
-        InventoryLoader.h
         InventoryLoader.cpp
-        InventoryModel.h
+        InventoryLoader.h
         InventoryModel.cpp
+        InventoryModel.h
         MainWindow.cpp
         MainWindow.h
         MiraMap.cpp
         MiraMap.h
-        RunOptionsWidget.h
         RunOptionsWidget.cpp
+        RunOptionsWidget.h
         SiteListLoader.cpp
         SiteListLoader.h
-        SliderWithValWidget.h
         SliderWithValWidget.cpp
-        SolutionWidget.h
+        SliderWithValWidget.h
         SolutionWidget.cpp
-        SolverRunner.h
+        SolutionWidget.h
         SolverRunner.cpp
-        themeIcon.h
-        themeIcon.cpp
+        SolverRunner.h
         main.cpp
+        themeIcon.cpp
+        themeIcon.h
 )
 
 # Application icon

--- a/src/xenoprobes_gui/DoubleSliderWithValWidget.cpp
+++ b/src/xenoprobes_gui/DoubleSliderWithValWidget.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file DoubleSliderWithValWidget.cpp
+ *
+ * @author Minneyar
+ * @date 03/31/2025
+ * @copyright GNU GPLv3
+ */
+
+#include "DoubleSliderWithValWidget.h"
+
+#include <QHBoxLayout>
+
+DoubleSliderWithValWidget::DoubleSliderWithValWidget(QWidget *parent)
+: QWidget(parent)
+, slider_(new QSlider(Qt::Horizontal, this))
+, spinBox_(new QDoubleSpinBox(this))
+{
+  auto *layout = new QHBoxLayout(this);
+  layout->addWidget(slider_);
+  layout->addWidget(spinBox_);
+  connect(slider_, &QSlider::valueChanged, this,
+          &DoubleSliderWithValWidget::handleQSliderChange);
+  connect(spinBox_, &QDoubleSpinBox::valueChanged, this,
+          &DoubleSliderWithValWidget::handleQDoubleSpinBoxChange);
+}
+
+void DoubleSliderWithValWidget::handleQSliderChange(int value) {
+  auto scaledValue = static_cast<double>(value) / SCALING_FACTOR;
+  if (std::fabs(scaledValue - spinBox_->value()) > 0.001) {
+    spinBox_->setValue(scaledValue);
+  }
+  Q_EMIT(valueChanged(scaledValue));
+}
+
+void DoubleSliderWithValWidget::handleQDoubleSpinBoxChange(double value) {
+  auto scaledValue = static_cast<int>(value * SCALING_FACTOR);
+  if (scaledValue != slider_->value()) {
+    slider_->setValue(scaledValue);
+  }
+  Q_EMIT(valueChanged(value));
+}
+void DoubleSliderWithValWidget::setMinimum(double minimum) {
+  slider_->setMinimum(static_cast<int>(minimum * SCALING_FACTOR));
+  spinBox_->setMinimum(minimum);
+}
+
+void DoubleSliderWithValWidget::setMaximum(double maximum) {
+  slider_->setMaximum(static_cast<int>(maximum * SCALING_FACTOR));
+  spinBox_->setMaximum(maximum);
+}
+
+void DoubleSliderWithValWidget::setValue(double value) {
+  slider_->setValue(static_cast<int>(value * SCALING_FACTOR));
+  spinBox_->setValue(value);
+}

--- a/src/xenoprobes_gui/DoubleSliderWithValWidget.h
+++ b/src/xenoprobes_gui/DoubleSliderWithValWidget.h
@@ -1,0 +1,46 @@
+/**
+ * @file DoubleSliderWithValWidget.h
+ *
+ * @author Minneyar
+ * @date 3/31/2025
+ * @copyright GNU GPLv3
+ */
+
+#ifndef DOUBLESLIDERWITHVALWIDGET_H
+#define DOUBLESLIDERWITHVALWIDGET_H
+
+#include <QSlider>
+#include <QDoubleSpinBox>
+#include <QWidget>
+
+/**
+ * A QSlider with a matching QDoubleSpinBox.
+ * QSlider only supports int values and there is no equivalent floating point version, so this scales the value stored
+ * in the QDoubleSpinBox up by 1000 so it can be stored in an int with three decimals of precision.
+ */
+class DoubleSliderWithValWidget : public QWidget {
+  Q_OBJECT
+public:
+  explicit DoubleSliderWithValWidget(QWidget *parent = nullptr);
+
+  [[nodiscard]] QSlider *slider() { return slider_; }
+  [[nodiscard]] QDoubleSpinBox *spinBox() { return spinBox_; }
+  void setMinimum(double minimum);
+  void setMaximum(double maximum);
+  void setValue(double value);
+  [[nodiscard]] double value() const { return spinBox_->value(); }
+
+  Q_SIGNALS:
+    void valueChanged(double value);
+
+private:
+  QSlider *slider_;
+  QDoubleSpinBox *spinBox_;
+
+  void handleQSliderChange(int value);
+  void handleQDoubleSpinBoxChange(double value);
+
+  static constexpr double SCALING_FACTOR = 1000.0;
+};
+
+#endif // DOUBLESLIDERWITHVALWIDGET_H

--- a/src/xenoprobes_gui/RunOptions.h
+++ b/src/xenoprobes_gui/RunOptions.h
@@ -14,6 +14,8 @@ struct RunOptions {
   int storageWeight = 1000;
   int revenueWeight = 10;
   int productionWeight = 1;
+  double oreMultiplier = 1.0;
+  bool requireOres = false;
   int iterations = 2000;
   int population = 200;
   int offsprings = 100;

--- a/src/xenoprobes_gui/RunOptionsWidget.cpp
+++ b/src/xenoprobes_gui/RunOptionsWidget.cpp
@@ -52,8 +52,16 @@ RunOptionsWidget::RunOptionsWidget(QWidget *parent)
           &RunOptionsWidget::settingsChanged);
   layout->addWidget(new QLabel(tr("Require Ores:"), this));
   layout->addWidget(requireOres_);
-  connect(requireOres_, &QCheckBox::checkStateChanged, this,
-          &RunOptionsWidget::settingsChanged);
+
+  connect(requireOres_,
+#if QT_VERSION >= QT_VERSION_CHECK(6, 7, 0)
+    &QCheckBox::checkStateChanged,
+#else
+    &QCheckBox::stateChanged,
+#endif
+    this,
+    &RunOptionsWidget::settingsChanged);
+
   layout->addWidget(new QLabel(tr("Iterations:"), this));
   layout->addWidget(iterations_);
   iterations_->setMinimum(1);

--- a/src/xenoprobes_gui/RunOptionsWidget.cpp
+++ b/src/xenoprobes_gui/RunOptionsWidget.cpp
@@ -47,7 +47,7 @@ RunOptionsWidget::RunOptionsWidget(QWidget *parent)
   layout->addWidget(new QLabel(tr("Ore Multiplier:"), this));
   layout->addWidget(oreMultiplier_);
   oreMultiplier_->setMinimum(0.0);
-  oreMultiplier_->setMaximum(10);
+  oreMultiplier_->setMaximum(1000);
   connect(oreMultiplier_, &DoubleSliderWithValWidget::valueChanged, this,
           &RunOptionsWidget::settingsChanged);
   layout->addWidget(new QLabel(tr("Require Ores:"), this));

--- a/src/xenoprobes_gui/RunOptionsWidget.cpp
+++ b/src/xenoprobes_gui/RunOptionsWidget.cpp
@@ -21,7 +21,10 @@ RunOptionsWidget::RunOptionsWidget(QWidget *parent)
       population_(new SliderWithValWidget(this)),
       offsprings_(new SliderWithValWidget(this)),
       mutation_(new SliderWithValWidget(this)),
-      threads_(new SliderWithValWidget(this)) {
+      threads_(new SliderWithValWidget(this)),
+      oreMultiplier_(new DoubleSliderWithValWidget(this)),
+      requireOres_(new QCheckBox(this))
+{
   auto *layout = new QVBoxLayout(this);
   layout->addWidget(new QLabel(tr("Storage Weight:"), this));
   layout->addWidget(storageWeight_);
@@ -40,6 +43,16 @@ RunOptionsWidget::RunOptionsWidget(QWidget *parent)
   productionWeight_->setMinimum(0);
   productionWeight_->setMaximum(1000);
   connect(productionWeight_, &SliderWithValWidget::valueChanged, this,
+          &RunOptionsWidget::settingsChanged);
+  layout->addWidget(new QLabel(tr("Ore Multiplier:"), this));
+  layout->addWidget(oreMultiplier_);
+  oreMultiplier_->setMinimum(0.0);
+  oreMultiplier_->setMaximum(10);
+  connect(oreMultiplier_, &DoubleSliderWithValWidget::valueChanged, this,
+          &RunOptionsWidget::settingsChanged);
+  layout->addWidget(new QLabel(tr("Require Ores:"), this));
+  layout->addWidget(requireOres_);
+  connect(requireOres_, &QCheckBox::checkStateChanged, this,
           &RunOptionsWidget::settingsChanged);
   layout->addWidget(new QLabel(tr("Iterations:"), this));
   layout->addWidget(iterations_);
@@ -80,20 +93,19 @@ RunOptionsWidget::RunOptionsWidget(QWidget *parent)
           &RunOptionsWidget::applyDefaultValues);
 
   // Match spinbox widths for aesthetics.
-  const auto allWidgets = {
-      storageWeight_, revenueWeight_, productionWeight_, iterations_,
-      population_,    offsprings_,    mutation_,         threads_,
+  const std::vector<QAbstractSpinBox*> allWidgets = {
+    storageWeight_->spinBox(), revenueWeight_->spinBox(), productionWeight_->spinBox(), iterations_->spinBox(),
+    population_->spinBox(), offsprings_->spinBox(), mutation_->spinBox(), threads_->spinBox(), oreMultiplier_->spinBox()
   };
   const auto maxWidth =
       std::ranges::max(allWidgets,
-                       [](SliderWithValWidget *lhs, SliderWithValWidget *rhs) {
-                         return lhs->spinBox()->width() <
-                                rhs->spinBox()->width();
+                       [](QAbstractSpinBox *lhs, QAbstractSpinBox *rhs) {
+                         return lhs->width() <
+                                rhs->width();
                        })
-          ->spinBox()
           ->width();
   for (auto *widget : allWidgets) {
-    widget->spinBox()->setMinimumWidth(maxWidth);
+    widget->setMinimumWidth(maxWidth);
   }
 }
 
@@ -102,6 +114,8 @@ QJsonValue RunOptionsWidget::optionsToJson(const RunOptions &options) {
   json["storageWeight"] = options.storageWeight;
   json["revenueWeight"] = options.revenueWeight;
   json["productionWeight"] = options.productionWeight;
+  json["oreMultiplier"] = options.oreMultiplier;
+  json["requireOres"] = options.requireOres;
   json["iterations"] = options.iterations;
   json["population"] = options.population;
   json["offsprings"] = options.offsprings;
@@ -136,6 +150,18 @@ RunOptions RunOptionsWidget::optionsFromJson(const QJsonValue &json) {
   }
   options.productionWeight = json["productionWeight"].toInt();
 
+  if (!jsonObj.contains("oreMultiplier") ||
+    !jsonObj["oreMultiplier"].isDouble()) {
+    throw std::runtime_error("Bad oreMultiplier");
+  }
+  options.oreMultiplier = json["oreMultiplier"].toDouble();
+
+  if (!jsonObj.contains("requireOres") ||
+    !jsonObj["requireOres"].isBool()) {
+    throw std::runtime_error("Bad requireOres");
+  }
+  options.requireOres = json["requireOres"].toBool();
+
   if (!jsonObj.contains("iterations") || !jsonObj["iterations"].isDouble()) {
     throw std::runtime_error("Bad iterations");
   }
@@ -166,12 +192,14 @@ RunOptions RunOptionsWidget::optionsFromJson(const QJsonValue &json) {
 
 void RunOptionsWidget::applyDefaultValues() {
   const RunOptions defaults;
-  storageWeight_->setValue(defaults.storageWeight);
-  revenueWeight_->setValue(defaults.revenueWeight);
-  productionWeight_->setValue(defaults.productionWeight);
-  iterations_->setValue(defaults.iterations);
-  population_->setValue(defaults.population);
-  offsprings_->setValue(defaults.offsprings);
-  mutation_->setValue(defaults.mutation);
-  threads_->setValue(defaults.threads);
+  setStorageWeight(defaults.storageWeight);
+  setRevenueWeight(defaults.revenueWeight);
+  setProductionWeight(defaults.productionWeight);
+  setOreMultiplier(defaults.oreMultiplier);
+  setRequireOres(defaults.requireOres);
+  setIterations(defaults.iterations);
+  setPopulation(defaults.population);
+  setOffsprings(defaults.offsprings);
+  setMutation(defaults.mutation);
+  setThreads(defaults.threads);
 }

--- a/src/xenoprobes_gui/RunOptionsWidget.h
+++ b/src/xenoprobes_gui/RunOptionsWidget.h
@@ -9,10 +9,14 @@
 #ifndef RUNOPTIONSWIDGET_H
 #define RUNOPTIONSWIDGET_H
 
-#include "SliderWithValWidget.h"
+#include <QCheckBox>
+
 #include <QJsonValue>
 #include <QWidget>
+
+#include "DoubleSliderWithValWidget.h"
 #include "RunOptions.h"
+#include "SliderWithValWidget.h"
 
 class RunOptionsWidget : public QWidget {
   Q_OBJECT
@@ -24,49 +28,65 @@ public:
   explicit RunOptionsWidget(QWidget *parent = nullptr);
   [[nodiscard]] RunOptions options() const {
     return {
-        .storageWeight = storageWeight_->value(),
-        .revenueWeight = revenueWeight_->value(),
-        .productionWeight = productionWeight_->value(),
-        .iterations = iterations_->value(),
-        .population = population_->value(),
-        .offsprings = offsprings_->value(),
-        .mutation = mutation_->value(),
-        .threads = threads_->value(),
+        .storageWeight = storageWeight(),
+        .revenueWeight = revenueWeight(),
+        .productionWeight = productionWeight(),
+        .oreMultiplier = oreMultiplier(),
+        .requireOres = requireOres(),
+        .iterations = iterations(),
+        .population = population(),
+        .offsprings = offsprings(),
+        .mutation = mutation(),
+        .threads = threads(),
     };
   }
   void setOptions(const RunOptions &options) {
-    storageWeight_->setValue(options.storageWeight);
-    revenueWeight_->setValue(options.revenueWeight);
-    productionWeight_->setValue(options.productionWeight);
-    iterations_->setValue(options.iterations);
-    population_->setValue(options.population);
-    offsprings_->setValue(options.offsprings);
-    mutation_->setValue(options.mutation);
-    threads_->setValue(options.threads);
+    setStorageWeight(options.storageWeight);
+    setRevenueWeight(options.revenueWeight);
+    setProductionWeight(options.productionWeight);
+    setOreMultiplier(options.oreMultiplier);
+    setRequireOres(options.requireOres);
+    setIterations(options.iterations);
+    setPopulation(options.population);
+    setOffsprings(options.offsprings);
+    setMutation(options.mutation);
+    setThreads(options.threads);
   }
-  [[nodiscard]] unsigned int storageWeight() { return storageWeight_->value(); }
+  [[nodiscard]] int storageWeight() const { return storageWeight_->value(); }
   void setStorageWeight(int storageWeight) {
     storageWeight_->setValue(storageWeight);
   }
-  [[nodiscard]] unsigned int revenueWeight() { return revenueWeight_->value(); }
+  [[nodiscard]] int revenueWeight() const { return revenueWeight_->value(); }
   void setRevenueWeight(int revenueWeight) {
     revenueWeight_->setValue(revenueWeight);
   }
-  [[nodiscard]] unsigned int productionWeight() {
+  [[nodiscard]] int productionWeight() const {
     return productionWeight_->value();
   }
   void setProductionWeight(int productionWeight) {
     productionWeight_->setValue(productionWeight);
   }
-  [[nodiscard]] unsigned int iterations() { return iterations_->value(); }
+  [[nodiscard]] double oreMultiplier() const {
+    return oreMultiplier_->value();
+  }
+  void setOreMultiplier(double oreMultiplier) {
+    oreMultiplier_->setValue(oreMultiplier);
+  }
+  [[nodiscard]] bool requireOres() const {
+    return requireOres_->checkState() == Qt::Checked;
+  }
+  void setRequireOres(bool requireOres) {
+    requireOres_->setCheckState(requireOres ? Qt::Checked : Qt::Unchecked);
+  }
+  [[nodiscard]] int iterations() const { return iterations_->value(); }
   void setIterations(int iterations) { iterations_->setValue(iterations); }
-  [[nodiscard]] unsigned int population() { return population_->value(); }
+  [[nodiscard]] int population() const { return population_->value(); }
   void setPopulation(int population) { population_->setValue(population); }
-  [[nodiscard]] unsigned int offsprings() { return offsprings_->value(); }
+  [[nodiscard]] int offsprings() const { return offsprings_->value(); }
   void setOffsprings(int offsprings) { offsprings_->setValue(offsprings); }
-  [[nodiscard]] unsigned int mutation() { return mutation_->value(); }
+  [[nodiscard]] int mutation() const { return mutation_->value(); }
   void setMutation(int mutation) { mutation_->setValue(mutation); }
-  [[nodiscard]] unsigned int threads() { return threads_->value(); }
+  [[nodiscard]] int threads() const { return threads_->value(); }
   void setThreads(int threads) { threads_->setValue(threads); }
 
 Q_SIGNALS:
@@ -84,6 +104,8 @@ private:
   SliderWithValWidget *offsprings_;
   SliderWithValWidget *mutation_;
   SliderWithValWidget *threads_;
+  DoubleSliderWithValWidget *oreMultiplier_;
+  QCheckBox *requireOres_;
 };
 
 #endif // RUNOPTIONSWIDGET_H

--- a/src/xenoprobes_gui/SliderWithValWidget.cpp
+++ b/src/xenoprobes_gui/SliderWithValWidget.cpp
@@ -11,8 +11,10 @@
 #include <QHBoxLayout>
 
 SliderWithValWidget::SliderWithValWidget(QWidget *parent)
-    : QWidget(parent), slider_(new QSlider(Qt::Horizontal, this)),
-      spinBox_(new QSpinBox(this)) {
+: QWidget(parent)
+, slider_(new QSlider(Qt::Horizontal, this))
+, spinBox_(new QSpinBox(this))
+{
   auto *layout = new QHBoxLayout(this);
   layout->addWidget(slider_);
   layout->addWidget(spinBox_);

--- a/src/xenoprobes_gui/SolverRunner.cpp
+++ b/src/xenoprobes_gui/SolverRunner.cpp
@@ -19,6 +19,8 @@ void SolverRunner::run() {
   probeOptimizer_->setStorageWeight(runOptions_.storageWeight);
   probeOptimizer_->setRevenueWeight(runOptions_.revenueWeight);
   probeOptimizer_->setProductionWeight(runOptions_.productionWeight);
+  probeOptimizer_->setOreMultiplier(runOptions_.oreMultiplier);
+  probeOptimizer_->setRequireOres(runOptions_.requireOres);
   probeOptimizer_->setMaxIterations(runOptions_.iterations);
   probeOptimizer_->setNumOffsprings(runOptions_.offsprings);
   probeOptimizer_->setMutationRate(runOptions_.mutation / 100.0);


### PR DESCRIPTION
Added 2 new options around Ores:
- Added the `--oremultiplier <i>` argument that applies a multiplier to the weight of a Node when it has a mining probe assigned and produces an ore.
- Added the `--requireores` flag that sets the weight of an arrangement to 0 when not all ores are acquired.

While not perfect these two options, especially the last one, ensures that you get a setup that mines each ore at least once. I was gonna try to go add it to the GUI, but I just can't compile things now, at least not under Windows. I can compile and test under WSL, but the GUI won't run in WSL, so I wasn't comfortable trying to blindly make changes to it.